### PR TITLE
mcrypt_decrypt replaced by openssl_decrypt

### DIFF
--- a/src/Connect2PayClient.php
+++ b/src/Connect2PayClient.php
@@ -1032,7 +1032,8 @@ class Connect2PayClient {
     $binData = $this->urlsafe_base64_decode($encryptedData);
 
     // Decrypting
-    $json = mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $key, $binData, MCRYPT_MODE_ECB);
+    //$json = mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $key, $binData, MCRYPT_MODE_ECB);
+    $json = openssl_decrypt($binData, 'AES-128-ECB', $key, OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
 
     if ($json) {
       // Remove PKCS#5 padding


### PR DESCRIPTION
replaced mcrypt_decrypt which is deprecated in PHP 7.1